### PR TITLE
feat(youtube/alternative-thumbnails): Add check for DeArrow API

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
@@ -88,10 +88,6 @@ public final class AlternativeThumbnailsPatch {
 
             StringBuilder builder = new StringBuilder();
 
-            // DeArrow Implementation
-            if (SettingsEnum.ALT_THUMBNAIL_DEARROW.getBoolean()) {
-                builder.append(String.format(DE_ARROW_THUMBNAILS_API, decodedUrl.videoId));
-            }
             builder.append(decodedUrl.urlPrefix);
             builder.append(decodedUrl.videoId).append('/');
             builder.append(qualityToUse.getAltImageNameToUse());
@@ -100,6 +96,11 @@ public final class AlternativeThumbnailsPatch {
             String sanitizedReplacement = builder.toString();
             if (!VerifiedQualities.verifyAltThumbnailExist(decodedUrl.videoId, qualityToUse, sanitizedReplacement)) {
                 return originalUrl;
+            }
+
+            // DeArrow Implementation
+            if (SettingsEnum.ALT_THUMBNAIL_DEARROW.getBoolean()) {
+                builder.insert(String.format(DE_ARROW_THUMBNAILS_API, decodedUrl.videoId));
             }
 
             // URL tracking parameters. Presumably they are to determine if a user has viewed a thumbnail.

--- a/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
@@ -71,6 +71,8 @@ public final class AlternativeThumbnailsPatch {
             if (!SettingsEnum.ALT_THUMBNAIL_ENABLED.getBoolean()) {
                 return originalUrl;
             }
+            if (originalUrl.contains("_live.")) return originalUrl; // Livestream video in feed.
+
             DecodedThumbnailUrl decodedUrl = DecodedThumbnailUrl.decodeImageUrl(originalUrl);
             if (decodedUrl == null) {
                 return originalUrl; // Not a thumbnail.
@@ -144,10 +146,6 @@ public final class AlternativeThumbnailsPatch {
         }
     }
 
-    private static boolean skipThumbNailChecking() {
-        return SettingsEnum.ALT_THUMBNAIL_SKIP_CHECKING.getBoolean() || SettingsEnum.ALT_THUMBNAIL_DEARROW.getBoolean();
-    }
-
     private enum ThumbnailQuality {
         // In order of lowest to highest resolution.
         DEFAULT("default", ""), // effective alt name is 1.jpg, 2.jpg, 3.jpg
@@ -205,7 +203,7 @@ public final class AlternativeThumbnailsPatch {
                 return null; // Not a thumbnail.
             }
 
-            final boolean useFastQuality = skipThumbNailChecking();
+            final boolean useFastQuality = SettingsEnum.ALT_THUMBNAIL_SKIP_CHECKING.getBoolean();
             // SD is max resolution for fast alt images.
             return switch (quality) {
                 // SD alt images have somewhat worse quality with washed out color and poor contrast.
@@ -271,7 +269,7 @@ public final class AlternativeThumbnailsPatch {
             synchronized (altVideoIdLookup) {
                 verified = altVideoIdLookup.get(videoId);
                 if (verified == null) {
-                    if (skipThumbNailChecking()) {
+                    if (SettingsEnum.ALT_THUMBNAIL_SKIP_CHECKING.getBoolean()) {
                         // For fast quality, skip checking if the alt thumbnail exists.
                         return true;
                     }
@@ -320,7 +318,7 @@ public final class AlternativeThumbnailsPatch {
             if (lowestQualityNotAvailable != null && lowestQualityNotAvailable.ordinal() <= quality.ordinal()) {
                 return false; // Previously verified as not existing.
             }
-            if (skipThumbNailChecking()) {
+            if (SettingsEnum.ALT_THUMBNAIL_SKIP_CHECKING.getBoolean()) {
                 return true; // Unknown if it exists or not.  Use the URL anyways and update afterwards if loading fails.
             }
 

--- a/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
@@ -93,19 +93,20 @@ public final class AlternativeThumbnailsPatch {
             builder.append(qualityToUse.getAltImageNameToUse());
             builder.append('.').append(decodedUrl.imageExtension);
 
+            // URL tracking parameters. Presumably they are to determine if a user has viewed a thumbnail.
+            // This likely is used for recommendations, so they are retained if present.
+            builder.append(decodedUrl.urlTrackingParameters);
+
             String sanitizedReplacement = builder.toString();
             if (!VerifiedQualities.verifyAltThumbnailExist(decodedUrl.videoId, qualityToUse, sanitizedReplacement)) {
-                return originalUrl;
+                builder.setLength(0);
+                builder.append(originalUrl);
             }
 
             // DeArrow Implementation
             if (SettingsEnum.ALT_THUMBNAIL_DEARROW.getBoolean()) {
                 builder.insert(0, String.format(DE_ARROW_THUMBNAILS_API, decodedUrl.videoId));
             }
-
-            // URL tracking parameters. Presumably they are to determine if a user has viewed a thumbnail.
-            // This likely is used for recommendations, so they are retained if present.
-            builder.append(decodedUrl.urlTrackingParameters);
 
             return builder.toString();
         } catch (Exception ex) {

--- a/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/layout/AlternativeThumbnailsPatch.java
@@ -100,7 +100,7 @@ public final class AlternativeThumbnailsPatch {
 
             // DeArrow Implementation
             if (SettingsEnum.ALT_THUMBNAIL_DEARROW.getBoolean()) {
-                builder.insert(String.format(DE_ARROW_THUMBNAILS_API, decodedUrl.videoId));
+                builder.insert(0, String.format(DE_ARROW_THUMBNAILS_API, decodedUrl.videoId));
             }
 
             // URL tracking parameters. Presumably they are to determine if a user has viewed a thumbnail.

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReVancedSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReVancedSettingsFragment.java
@@ -161,7 +161,6 @@ public class ReVancedSettingsFragment extends PreferenceFragment {
         NavigationPreferenceLinks();
         QuickActionsPreferenceLinks();
         SpeedOverlayPreferenceLinks();
-        AlternativeThumbnailsPreferenceLinks();
         TabletLayoutLinks();
         setBackupRestorePreference();
         setExternalDownloaderPreference();
@@ -215,17 +214,6 @@ public class ReVancedSettingsFragment extends PreferenceFragment {
                 SettingsEnum.HIDE_QUICK_ACTIONS_RELATED_VIDEO,
                 SettingsEnum.HIDE_QUICK_ACTIONS_SHARE_BUTTON,
                 SettingsEnum.SHOW_FULLSCREEN_TITLE
-        );
-    }
-
-    /**
-     * Enable/Disable Preference related to Alternative Thumbnails
-     */
-    public void AlternativeThumbnailsPreferenceLinks() {
-        enableDisablePreferences(
-                SettingsEnum.ALT_THUMBNAIL_DEARROW.getBoolean(),
-                SettingsEnum.ALT_THUMBNAIL_SKIP_CHECKING,
-                SettingsEnum.ALT_THUMBNAIL_TYPE
         );
     }
 


### PR DESCRIPTION
I also exclude `ALT_THUMBNAIL_TYPE` from disabling because when DeArrow image not found, it will auto-redirect to Alt image and use `ALT_THUMBNAIL_TYPE` settings