### PR TITLE
Remove double quotes for r/place button

### DIFF
--- a/app/src/main/java/app/revanced/reddit/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/reddit/settings/SettingsEnum.java
@@ -41,7 +41,7 @@ public enum SettingsEnum {
             "Hides the recently visited shelf in the sidebar."),
     HIDE_TOOLBAR_BUTTON("revanced_hide_toolbar_button", BOOLEAN, FALSE, true,
             "Hide toolbar button",
-            "Hides the \"r/place\" or Reddit recap button in the toolbar."),
+            "Hides the r/place or Reddit recap button in the toolbar."),
     OPEN_LINKS_DIRECTLY("revanced_open_links_directly", BOOLEAN, TRUE,
             "Open links directly",
             "Skips over redirection URLs in external links."),


### PR DESCRIPTION
Sorry, I realized that the r/place button shouldn't have double quotes since there's no button label. It's just an icon button

I also reflected this new change in the patch description in the PR in the patches repository