### PR TITLE
fix(YouTube/Return shorts channel name): Add fallback for `Fetch from rss feed`

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/components/ReturnYouTubeChannelNameFilterPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/components/ReturnYouTubeChannelNameFilterPatch.java
@@ -16,7 +16,7 @@ public final class ReturnYouTubeChannelNameFilterPatch extends Filter {
 
     public ReturnYouTubeChannelNameFilterPatch() {
         addPathCallbacks(
-                new StringFilterGroup(Settings.RETURN_SHORTS_CHANNEL_NAME_FETCH, "|reel_channel_bar_inner.eml|")
+                new StringFilterGroup(Settings.RETURN_SHORTS_CHANNEL_NAME, "|reel_channel_bar_inner.eml|")
         );
         shortsChannelBarAvatarFilterGroup.addAll(
                 new ByteArrayFilterGroup(Settings.RETURN_SHORTS_CHANNEL_NAME, "/@")

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
@@ -24,7 +24,7 @@ import app.revanced.integrations.youtube.settings.Settings;
 public class ReturnYouTubeChannelNamePatch {
 
     /**
-     * Last unique video id's loaded.  Value is ignored and Map is treated as a Set.
+     * Last unique channel name's loaded.  Value is ignored and Map is treated as a Set.
      * Cannot use {@link LinkedHashSet} because it's missing #removeEldestEntry().
      */
     private static final Map<String, String> channelNameMap = new LinkedHashMap<>() {

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
@@ -32,7 +32,7 @@ public class ReturnYouTubeChannelNamePatch {
          * Number of video id's to keep track of for searching thru the buffer.
          * A minimum value of 3 should be sufficient, but check a few more just in case.
          */
-        private static final int NUMBER_OF_LAST_CHANNEL_IDS_TO_TRACK = 10;
+        private static final int NUMBER_OF_LAST_CHANNEL_IDS_TO_TRACK = 20;
 
         @Override
         protected boolean removeEldestEntry(Map.Entry eldest) {
@@ -87,32 +87,22 @@ public class ReturnYouTubeChannelNamePatch {
     }
 
     private static CharSequence getChannelName(String handle) {
-        final String trimedString = handle.replaceAll(NON_BREAK_SPACE_CHARACTER,"");
+        final String trimedHandle = handle.replaceAll(NON_BREAK_SPACE_CHARACTER, "");
         String replacedChannelName;
 
-        if (Settings.RETURN_SHORTS_CHANNEL_NAME_FETCH.get()) {
-            String channelName = channelNameMap.get(trimedString);
-            if (channelName != null) {
-                replacedChannelName = channelName;
-                if (handle.contains(NON_BREAK_SPACE_CHARACTER)) {
-                    replacedChannelName += NON_BREAK_SPACE_CHARACTER;
-                }
-                final String finalChannelName = replacedChannelName;
-                Logger.printDebug(() -> "Replace Handle " + handle + " to " + finalChannelName);
-                return replacedChannelName;
-            }
-        } else {
-            if (!channelName.isEmpty()) {
-                replacedChannelName = channelName;
-                if (handle.contains(NON_BREAK_SPACE_CHARACTER)) {
-                    replacedChannelName += NON_BREAK_SPACE_CHARACTER;
-                }
-                final String finalChannelName = replacedChannelName;
-                Logger.printDebug(() -> "Replace Handle " + handle + " to " + finalChannelName);
-                return replacedChannelName;
-            }
+        // Priority: Prefetch channel name via api -> Channel name via hook -> Fallback to the original handle
+        String cachedChannelName = channelNameMap.get(trimedHandle);
+        if (cachedChannelName != null) {
+            replacedChannelName = cachedChannelName;
+        } else if (!channelName.isEmpty()) {
+            replacedChannelName = channelName;
+        } else return handle;
+
+        if (handle.contains(NON_BREAK_SPACE_CHARACTER)) {
+            replacedChannelName += NON_BREAK_SPACE_CHARACTER;
         }
-        return handle;
+        Logger.printDebug(() -> "Replace Handle " + handle + " to " + replacedChannelName);
+        return replacedChannelName;
     }
 
     public synchronized static void setLastShortsChannelId(String handle, String channelId) {

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
@@ -29,14 +29,14 @@ public class ReturnYouTubeChannelNamePatch {
      */
     private static final Map<String, String> channelNameMap = new LinkedHashMap<>() {
         /**
-         * Number of channel id's to keep track of for searching thru the buffer.
+         * Number of channel name's to keep track of for searching thru the buffer.
          * A minimum value of 20 should be sufficient, but check a few more just in case.
          */
-        private static final int NUMBER_OF_LAST_CHANNEL_IDS_TO_TRACK = 20;
+        private static final int NUMBER_OF_LAST_CHANNEL_NAME_TO_TRACK = 20;
 
         @Override
         protected boolean removeEldestEntry(Map.Entry eldest) {
-            return size() > NUMBER_OF_LAST_CHANNEL_IDS_TO_TRACK;
+            return size() > NUMBER_OF_LAST_CHANNEL_NAME_TO_TRACK;
         }
     };
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
@@ -120,6 +120,7 @@ public class ReturnYouTubeChannelNamePatch {
             if (!matcher.find()) return;
             //noinspection deprecation
             String channelName = StringEscapeUtils.unescapeXml(Objects.requireNonNull(matcher.group(1)).split("</title>")[0]);
+            // Caching channel names are retrieved through the API only, to ensure accuracy
             if (channelNameMap.put(handle, channelName) == null) {
                 Logger.printDebug(() -> "Set Handle: " + handle + ", Channel Name: " + channelName);
             }

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
@@ -101,7 +101,8 @@ public class ReturnYouTubeChannelNamePatch {
         if (handle.contains(NON_BREAK_SPACE_CHARACTER)) {
             replacedChannelName += NON_BREAK_SPACE_CHARACTER;
         }
-        Logger.printDebug(() -> "Replace Handle " + handle + " to " + replacedChannelName);
+        String finalReplacedChannelName = replacedChannelName;
+        Logger.printDebug(() -> "Replace Handle " + handle + " to " + finalReplacedChannelName);
         return replacedChannelName;
     }
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
@@ -29,8 +29,8 @@ public class ReturnYouTubeChannelNamePatch {
      */
     private static final Map<String, String> channelNameMap = new LinkedHashMap<>() {
         /**
-         * Number of video id's to keep track of for searching thru the buffer.
-         * A minimum value of 3 should be sufficient, but check a few more just in case.
+         * Number of channel id's to keep track of for searching thru the buffer.
+         * A minimum value of 20 should be sufficient, but check a few more just in case.
          */
         private static final int NUMBER_OF_LAST_CHANNEL_IDS_TO_TRACK = 20;
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/utils/ReturnYouTubeChannelNamePatch.java
@@ -87,11 +87,11 @@ public class ReturnYouTubeChannelNamePatch {
     }
 
     private static CharSequence getChannelName(String handle) {
-        final String trimedHandle = handle.replaceAll(NON_BREAK_SPACE_CHARACTER, "");
+        final String trimmedHandle = handle.replaceAll(NON_BREAK_SPACE_CHARACTER, "");
         String replacedChannelName;
 
         // Priority: Prefetch channel name via api -> Channel name via hook -> Fallback to the original handle
-        String cachedChannelName = channelNameMap.get(trimedHandle);
+        String cachedChannelName = channelNameMap.get(trimmedHandle);
         if (cachedChannelName != null) {
             replacedChannelName = cachedChannelName;
         } else if (!channelName.isEmpty()) {

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -361,8 +361,6 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting HIDE_SHORTS_TOOLBAR = new BooleanSetting("revanced_hide_shorts_toolbar", FALSE, true);
     public static final BooleanSetting HIDE_SHORTS_NAVIGATION_BAR = new BooleanSetting("revanced_hide_shorts_navigation_bar", FALSE, true);
     public static final BooleanSetting RETURN_SHORTS_CHANNEL_NAME = new BooleanSetting("revanced_return_shorts_channel_name", FALSE);
-    public static final BooleanSetting RETURN_SHORTS_CHANNEL_NAME_FETCH = new BooleanSetting("revanced_return_shorts_channel_name_fetch", FALSE, parent(RETURN_SHORTS_CHANNEL_NAME));
-
 
     // PreferenceScreen: Swipe controls
     public static final BooleanSetting ENABLE_SWIPE_BRIGHTNESS = new BooleanSetting("revanced_enable_swipe_brightness", TRUE, true);


### PR DESCRIPTION
With these change, the patches will take advantage of the strengths of both methods, thereby ensuring the channel name is displayed correctly, while also speeding up display time.
#### Additional changes: Remove `Fetch from rss feed` settings