### PR TITLE
Fix crash when edit playlist 

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/player/PlayerPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/player/PlayerPatch.java
@@ -81,6 +81,9 @@ public class PlayerPatch {
     private static boolean isDescriptionPanel = false;
 
     public static void setContentDescription(String contentDescription) {
+        if(contentDescription==null){
+            return isDescriptionPanel = false;
+        }
         isDescriptionPanel = contentDescription.equals(descriptionString);
     }
 


### PR DESCRIPTION
Fix the issue : https://github.com/inotia00/revanced-integrations/issues/40

PS : i have zero knowledge of the repo so maybe wrong fix. What i understand is that method check if there is description panel in view or not and in edit dialog of playlist there is a place to enter description of playlist. Which causes this setContentDescription method and it check for panel existance
