### PR TITLE
fix(YouTube - Alternative Thumbnails Domains): Handle more thumbnails

### DIFF
--- a/app/src/main/java/app/revanced/integrations/music/patches/misc/AlternativeDomainPatch.java
+++ b/app/src/main/java/app/revanced/integrations/music/patches/misc/AlternativeDomainPatch.java
@@ -11,7 +11,7 @@ import app.revanced.integrations.shared.utils.Logger;
 @SuppressWarnings("unused")
 public final class AlternativeDomainPatch {
 
-    private static final String YOUTUBE_STATIC_THUMBNAILS_DOMAIN_REGEX = "(yt[3-4]|lh[3-6]|play-lh)\\.(ggpht|googleusercontent)\\.com";
+    private static final String YOUTUBE_STATIC_THUMBNAILS_DOMAIN_REGEX = "(ap[1-2]|gm[1-4]|gz[0]|(cp|ci|gp|lh)[3-6]|sp[1-3]|yt[3-4]|(play|ccp)-lh)\\.(ggpht|googleusercontent)\\.com";
 
     private static final Pattern YOUTUBE_STATIC_THUMBNAILS_DOMAIN_PATTERN = Pattern.compile(YOUTUBE_STATIC_THUMBNAILS_DOMAIN_REGEX);
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/alternativethumbnails/AlternativeThumbnailsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/alternativethumbnails/AlternativeThumbnailsPatch.java
@@ -142,7 +142,7 @@ public final class AlternativeThumbnailsPatch {
      * Regex to match youtube static thumbnails domain.
      * Used to find and replace blocked domain with a working ones
      */
-    private static final String YOUTUBE_STATIC_THUMBNAILS_DOMAIN_REGEX = "(yt[3-4]|lh[3-6]|play-lh)\\.(ggpht|googleusercontent)\\.com";
+    private static final String YOUTUBE_STATIC_THUMBNAILS_DOMAIN_REGEX = "(ap[1-2]|gm[1-4]|gz[0]|(cp|ci|gp|lh)[3-6]|sp[1-3]|yt[3-4]|(play|ccp)-lh)\\.(ggpht|googleusercontent)\\.com";
 
     private static final Pattern YOUTUBE_STATIC_THUMBNAILS_DOMAIN_PATTERN = Pattern.compile(YOUTUBE_STATIC_THUMBNAILS_DOMAIN_REGEX);
 


### PR DESCRIPTION
This regex was extracted from YouTube and edited to fit this patch
I also confirm that all thumbnails that are being handled only be used to get community post, channel profile, etc

Original regex:
```java
"((http(s)?):)?\\/\\/((((lh[3-6](-tt|-d[a-g,y,z]|-testonly(-rollout)?)?\\.((ggpht)|(googleusercontent)|(google)|(sandbox\\.google)))|(lh7\\-(eu|us|qw|rt)\\.((googleusercontent)|(google)))|((photos|testonly|work)\\.fife\\.usercontent\\.google)|([\\w\\-]+\\.fife\\.usercontent\\.google)|(([1-4]\\.bp\\.blogspot)|(bp[0-3]\\.blogger))|(ccp-lh\\.googleusercontent)|((((cp|ci|gp)[3-6])|(ap[1-2]))\\.(ggpht|googleusercontent))|(gm[1-4]\\.ggpht)|(play-(ti-)?lh\\.googleusercontent)|(gz0\\.googleusercontent)|(((yt[3-4])|(sp[1-3]))\\.(ggpht|googleusercontent)))\\.com)|(drive\\.google\\.com\\/drive\\-usercontent)|(dp[3-6]\\.googleusercontent\\.cn)|(lh[3-6]\\.(googleadsserving\\.cn|xn--9kr7l\\.com))|((photos|drive|contribution)\\-image\\-(dev|qa)(-auth|-cookie)?\\.corp\\.google\\.com)|(photos\\-image\\-dev\\-dl\\-(auth|eu|us)\\.corp\\.google\\.com)|((dev|dev2|dev3|qa|qa2|qa3|qa-red|qa-blue|canary)[-.]lighthouse\\.sandbox\\.google\\.com\\/image)|(image\\-(dev|qa)\\-lighthouse(-auth)?\\.sandbox\\.google\\.com(\\/image)?)|(drive\\-qa\\.corp\\.google\\.com\\/drive\\-usercontent))\\/"
```