### PR TITLE
feat(YouTube - Spoof Streaming Data): Parse `streamingData` to check if a video is livestream or not

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
@@ -77,7 +77,7 @@ public class StreamingDataRequest {
     private static final int MAX_MILLISECONDS_TO_WAIT_FOR_FETCH = 20 * 1000;
 
     /**
-     * Size of the byte buffer used to read/write the connection stream. 
+     * Size of the byte buffer used to read the connection stream. 
      */
     private static final int READ_BUFFER_SIZE = 8192;
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
@@ -258,9 +258,10 @@ public class StreamingDataRequest {
                                 }
 
                                 byte[] streamingDataByteArray = baos.toByteArray();
-                                if (isLiveStream(clientType, new ByteArrayInputStream(streamingDataByteArray)))
-                                    throw new IOException("Ignore IOS spoofing as it is livestream (video: " + videoId + ")");
-
+                                if (isLiveStream(clientType, new ByteArrayInputStream(streamingDataByteArray))) {
+                                    Logger.printDebug(() -> "Ignore IOS spoofing as it is a live stream (video: " + videoId + ")");
+                                    continue;
+                                }
                                 lastSpoofedClientType = clientType;
 
                                 return ByteBuffer.wrap(streamingDataByteArray);

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
@@ -253,11 +253,12 @@ public class StreamingDataRequest {
                             while ((bytesRead = inputStream.read(buffer)) >= 0) {
                                 baos.write(buffer, 0, bytesRead);
 
-                                // Only parsing first 8192 byte to check
                                 if (shouldSkipParsing) continue;
                                 shouldSkipParsing = true;
 
-                                if (isLiveStream(new String(buffer, 0, bytesRead))) {
+                                // Only parsing first 512 byte to check
+                                final int lengthToCheck = Math.min(bytesRead, 512);
+                                if (isLiveStream(new String(buffer, 0, lengthToCheck))) {
                                     throw new IOException("Ignore IOS spoofing as it is livestream (video: " + videoId + ")");
                                 }
                             }

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/misc/requests/StreamingDataRequest.java
@@ -167,7 +167,10 @@ public class StreamingDataRequest {
 
     private static boolean isLiveStream(String streamingData) {
         // Check the source parameter in streamingData
-        return streamingData.contains("yt_live_broadcast") || streamingData.contains("yt_premiere_broadcast");
+        return Stream.of(
+            "yt_live_broadcast",      // Live video
+            "yt_premiere_broadcast"   // Premiere video (Upcoming video)
+        ).anyMatch(streamingData::contains);
     }
 
     private static final String[] REQUEST_HEADER_KEYS = {

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -545,7 +545,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting SPOOF_STREAMING_DATA = new BooleanSetting("revanced_spoof_streaming_data", TRUE, true, "revanced_spoof_streaming_data_user_dialog_message");
     public static final BooleanSetting SPOOF_STREAMING_DATA_IOS_FORCE_AVC = new BooleanSetting("revanced_spoof_streaming_data_ios_force_avc", FALSE, true,
             "revanced_spoof_streaming_data_ios_force_avc_user_dialog_message", new SpoofStreamingDataPatch.ForceiOSAVCAvailability());
-    public static final BooleanSetting SPOOF_STREAMING_DATA_IOS_COMPATIBILITY = new BooleanSetting("revanced_spoof_streaming_data_ios_compatibility", FALSE, true, new SpoofStreamingDataPatch.ForceiOSAVCAvailability());
+    public static final BooleanSetting SPOOF_STREAMING_DATA_IOS_COMPATIBILITY = new BooleanSetting("revanced_spoof_streaming_data_ios_compatibility", TRUE, true, new SpoofStreamingDataPatch.ForceiOSAVCAvailability());
     public static final EnumSetting<ClientType> SPOOF_STREAMING_DATA_TYPE = new EnumSetting<>("revanced_spoof_streaming_data_type", ClientType.IOS, true, parent(SPOOF_STREAMING_DATA));
     public static final BooleanSetting SPOOF_STREAMING_DATA_STATS_FOR_NERDS = new BooleanSetting("revanced_spoof_streaming_data_stats_for_nerds", TRUE, parent(SPOOF_STREAMING_DATA));
 

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -545,7 +545,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting SPOOF_STREAMING_DATA = new BooleanSetting("revanced_spoof_streaming_data", TRUE, true, "revanced_spoof_streaming_data_user_dialog_message");
     public static final BooleanSetting SPOOF_STREAMING_DATA_IOS_FORCE_AVC = new BooleanSetting("revanced_spoof_streaming_data_ios_force_avc", FALSE, true,
             "revanced_spoof_streaming_data_ios_force_avc_user_dialog_message", new SpoofStreamingDataPatch.ForceiOSAVCAvailability());
-    public static final BooleanSetting SPOOF_STREAMING_DATA_IOS_COMPATIBILITY = new BooleanSetting("revanced_spoof_streaming_data_ios_compatibility", TRUE, true, new SpoofStreamingDataPatch.ForceiOSAVCAvailability());
+    public static final BooleanSetting SPOOF_STREAMING_DATA_IOS_COMPATIBILITY = new BooleanSetting("revanced_spoof_streaming_data_ios_compatibility", FALSE, true, new SpoofStreamingDataPatch.ForceiOSAVCAvailability());
     public static final EnumSetting<ClientType> SPOOF_STREAMING_DATA_TYPE = new EnumSetting<>("revanced_spoof_streaming_data_type", ClientType.IOS, true, parent(SPOOF_STREAMING_DATA));
     public static final BooleanSetting SPOOF_STREAMING_DATA_STATS_FOR_NERDS = new BooleanSetting("revanced_spoof_streaming_data_stats_for_nerds", TRUE, parent(SPOOF_STREAMING_DATA));
 


### PR DESCRIPTION
If `iOS Compatibility mode` settings is turned:
- **On:** Fetch using Innertube API
- **Off:** Parse `streamingData`

We can working more in this approach to remove additational fetch completely.

Patches changes: https://github.com/inotia00/revanced-patches/pull/94