### PR TITLE
feat(YouTube - Shorts): Add a working Toolbar menu

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/shorts/ShortsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/shorts/ShortsPatch.java
@@ -1,26 +1,34 @@
 package app.revanced.integrations.youtube.patches.shorts;
 
-import static app.revanced.integrations.shared.utils.Utils.hideViewUnderCondition;
-import static app.revanced.integrations.youtube.utils.ExtendedUtils.validateValue;
-
+import android.app.AlertDialog;
+import android.content.Context;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
 import androidx.annotation.NonNull;
-
-import com.google.android.libraries.youtube.rendering.ui.pivotbar.PivotBar;
-
-import java.lang.ref.WeakReference;
-
+import app.revanced.integrations.shared.utils.Logger;
 import app.revanced.integrations.shared.utils.ResourceUtils;
 import app.revanced.integrations.shared.utils.Utils;
 import app.revanced.integrations.youtube.settings.Settings;
 import app.revanced.integrations.youtube.shared.ShortsPlayerState;
 import app.revanced.integrations.youtube.utils.VideoUtils;
+import com.google.android.libraries.youtube.rendering.ui.pivotbar.PivotBar;
+import org.apache.commons.lang3.StringUtils;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static app.revanced.integrations.shared.utils.ResourceUtils.getString;
+import static app.revanced.integrations.shared.utils.Utils.getChildView;
+import static app.revanced.integrations.shared.utils.Utils.hideViewUnderCondition;
+import static app.revanced.integrations.youtube.utils.ExtendedUtils.validateValue;
 
 @SuppressWarnings("unused")
 public class ShortsPatch {
@@ -69,6 +77,75 @@ public class ShortsPatch {
 
         return currentState;
     }
+
+    /**
+     * Injection point for the "More" button in the Shorts player
+     */
+    public static void showShortsToolbarMenu(String enumString, View toolbarView) {
+        if (!Settings.HOOK_MORE_BUTTON.get())
+            return;
+        if (!isMoreButton(enumString))
+            return;
+        ImageView imageView = getChildView((ViewGroup) toolbarView, view -> view instanceof ImageView);
+        if (imageView == null)
+            return;
+
+        imageView.setOnLongClickListener(button -> {
+            showMoreButtonDialog(toolbarView.getContext());
+            return true;
+        });
+    }
+
+    private static void showMoreButtonDialog(Context context) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(getString("revanced_hook_more_button_dialog_title"));
+
+        String copyLink = getString("revanced_hook_more_button_option_copy_link_title");
+        String copyLinkTimestamp = getString("revanced_hook_more_button_option_copy_link_timestamp_title");
+        String downloadShort = getString("revanced_hook_more_button_option_download_short_title");
+
+        List<String> optionsList = new ArrayList<>();
+        Map<String, Runnable> actions = new HashMap<>();
+
+        if (Settings.COPY_URL_SHORT_TOOLBAR_MENU.get()) {
+            optionsList.add(copyLink);
+            actions.put(copyLink, () -> VideoUtils.copyUrl(false));
+        }
+
+        if (Settings.COPY_URL_WITH_TIMESTAMP_SHORT_TOOLBAR_MENU.get()) {
+            optionsList.add(copyLinkTimestamp);
+            actions.put(copyLinkTimestamp, () -> VideoUtils.copyUrl(true));
+        }
+
+        if (Settings.DOWNLOAD_SHORT_TOOLBAR_MENU.get()) {
+            optionsList.add(downloadShort);
+            actions.put(downloadShort, VideoUtils::launchVideoExternalDownloader);
+        }
+
+        String[] options = optionsList.toArray(new String[0]);
+        builder.setItems(options, (dialog, which) -> {
+            String selectedOption = options[which];
+            Runnable action = actions.get(selectedOption);
+            if (action != null)
+                action.run();
+            else
+                Logger.printDebug(() -> "No action found for " + selectedOption);
+        });
+
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+
+    private static boolean isMoreButton(String enumString) {
+        return StringUtils.equalsAny(
+                enumString,
+                "MORE_VERT",
+                "MORE_VERT_BOLD"
+        );
+    }
+
 
     public static boolean disableResumingStartupShortsPlayer() {
         return Settings.DISABLE_RESUMING_SHORTS_PLAYER.get();

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/shorts/ShortsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/shorts/ShortsPatch.java
@@ -103,6 +103,7 @@ public class ShortsPatch {
         String copyLink = getString("revanced_hook_more_button_option_copy_link_title");
         String copyLinkTimestamp = getString("revanced_hook_more_button_option_copy_link_timestamp_title");
         String downloadShort = getString("revanced_hook_more_button_option_download_short_title");
+        String openInNormalPlayer = getString("revanced_hook_more_button_option_open_in_normal_player_title");
 
         List<String> optionsList = new ArrayList<>();
         Map<String, Runnable> actions = new HashMap<>();
@@ -120,6 +121,11 @@ public class ShortsPatch {
         if (Settings.DOWNLOAD_SHORT_TOOLBAR_MENU.get()) {
             optionsList.add(downloadShort);
             actions.put(downloadShort, VideoUtils::launchVideoExternalDownloader);
+        }
+
+        if (Settings.OPEN_IN_NORMAL_PLAYER_SHORT_TOOLBAR_MENU.get()) {
+            optionsList.add(openInNormalPlayer);
+            actions.put(openInNormalPlayer, VideoUtils::openVideo);
         }
 
         String[] options = optionsList.toArray(new String[0]);

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -469,6 +469,10 @@ public class Settings extends BaseSettings {
     public static final IntegerSetting META_PANEL_BOTTOM_MARGIN = new IntegerSetting("revanced_shorts_meta_panel_bottom_margin", 32, true, parent(ENABLE_TIME_STAMP));
     public static final BooleanSetting HIDE_SHORTS_TOOLBAR = new BooleanSetting("revanced_hide_shorts_toolbar", FALSE, true);
     public static final BooleanSetting HIDE_SHORTS_NAVIGATION_BAR = new BooleanSetting("revanced_hide_shorts_navigation_bar", FALSE, true);
+    public static final BooleanSetting HOOK_MORE_BUTTON = new BooleanSetting("revanced_hook_more_button", TRUE);
+    public static final BooleanSetting COPY_URL_SHORT_TOOLBAR_MENU = new BooleanSetting("revanced_hook_more_button_option_copy_link", TRUE);
+    public static final BooleanSetting COPY_URL_WITH_TIMESTAMP_SHORT_TOOLBAR_MENU = new BooleanSetting("revanced_hook_more_button_option_copy_link_timestamp", TRUE);
+    public static final BooleanSetting DOWNLOAD_SHORT_TOOLBAR_MENU = new BooleanSetting("revanced_hook_more_button_option_download_short", TRUE);
     public static final IntegerSetting SHORTS_NAVIGATION_BAR_HEIGHT_PERCENTAGE = new IntegerSetting("revanced_shorts_navigation_bar_height_percentage", 45, true, parent(HIDE_SHORTS_NAVIGATION_BAR));
     public static final BooleanSetting REPLACE_CHANNEL_HANDLE = new BooleanSetting("revanced_replace_channel_handle", FALSE, true);
 

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -473,6 +473,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting COPY_URL_SHORT_TOOLBAR_MENU = new BooleanSetting("revanced_hook_more_button_option_copy_link", TRUE);
     public static final BooleanSetting COPY_URL_WITH_TIMESTAMP_SHORT_TOOLBAR_MENU = new BooleanSetting("revanced_hook_more_button_option_copy_link_timestamp", TRUE);
     public static final BooleanSetting DOWNLOAD_SHORT_TOOLBAR_MENU = new BooleanSetting("revanced_hook_more_button_option_download_short", TRUE);
+    public static final BooleanSetting OPEN_IN_NORMAL_PLAYER_SHORT_TOOLBAR_MENU = new BooleanSetting("revanced_hook_more_button_option_open_in_normal_player", TRUE);
     public static final IntegerSetting SHORTS_NAVIGATION_BAR_HEIGHT_PERCENTAGE = new IntegerSetting("revanced_shorts_navigation_bar_height_percentage", 45, true, parent(HIDE_SHORTS_NAVIGATION_BAR));
     public static final BooleanSetting REPLACE_CHANNEL_HANDLE = new BooleanSetting("revanced_replace_channel_handle", FALSE, true);
 

--- a/app/src/main/java/app/revanced/integrations/youtube/utils/VideoUtils.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/utils/VideoUtils.java
@@ -25,13 +25,15 @@ import app.revanced.integrations.youtube.settings.Settings;
 import app.revanced.integrations.youtube.settings.preference.ExternalDownloaderPlaylistPreference;
 import app.revanced.integrations.youtube.settings.preference.ExternalDownloaderVideoPreference;
 import app.revanced.integrations.youtube.shared.PlaylistIdPrefix;
+import app.revanced.integrations.youtube.shared.ShortsPlayerState;
 import app.revanced.integrations.youtube.shared.VideoInformation;
 
 @SuppressWarnings("unused")
 public class VideoUtils extends IntentUtils {
     private static final String PLAYLIST_URL = "https://www.youtube.com/playlist?list=";
     private static final String VIDEO_URL = "https://youtu.be/";
-    private static final String VIDEO_SCHEME_FORMAT = "https://youtu.be/%s?t=%d";
+    private static final String VIDEO_SCHEME_INTENT_FORMAT = "vnd.youtube://%s?start=%d";
+    private static final String VIDEO_SCHEME_LINK_FORMAT = "https://youtu.be/%s?t=%d";
     private static final AtomicBoolean isExternalDownloaderLaunched = new AtomicBoolean(false);
 
     private static String getPlaylistUrl(String playlistId) {
@@ -62,7 +64,12 @@ public class VideoUtils extends IntentUtils {
     }
 
     private static String getVideoScheme(String videoId) {
-        return String.format(Locale.ENGLISH, VIDEO_SCHEME_FORMAT, videoId, VideoInformation.getVideoTimeInSeconds());
+        return String.format(
+            Locale.ENGLISH,
+            ShortsPlayerState.getCurrent().isClosed() ? VIDEO_SCHEME_INTENT_FORMAT : VIDEO_SCHEME_LINK_FORMAT,
+            videoId,
+            VideoInformation.getVideoTimeInSeconds()
+        );
     }
 
     public static void copyUrl(boolean withTimestamp) {

--- a/app/src/main/java/app/revanced/integrations/youtube/utils/VideoUtils.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/utils/VideoUtils.java
@@ -31,7 +31,7 @@ import app.revanced.integrations.youtube.shared.VideoInformation;
 public class VideoUtils extends IntentUtils {
     private static final String PLAYLIST_URL = "https://www.youtube.com/playlist?list=";
     private static final String VIDEO_URL = "https://youtu.be/";
-    private static final String VIDEO_SCHEME_FORMAT = "vnd.youtube://%s?start=%d";
+    private static final String VIDEO_SCHEME_FORMAT = "https://youtu.be/%s?t=%d";
     private static final AtomicBoolean isExternalDownloaderLaunched = new AtomicBoolean(false);
 
     private static String getPlaylistUrl(String playlistId) {


### PR DESCRIPTION
- **New Features**:  
  - **Custom Toolbar Access**: Long-pressing the "More" button opens a dedicated Shorts toolbar menu.  

In this toolbar menu we can copy the link of the video, or download the short.

patches: https://github.com/inotia00/revanced-patches/pull/101

major thanks to YT-Advanced and kitadai for the idea and the help through the implementation